### PR TITLE
Apply admin gradient background to user browse page

### DIFF
--- a/src/app/components/browse-courts-page/browse-courts-page.component.html
+++ b/src/app/components/browse-courts-page/browse-courts-page.component.html
@@ -1,4 +1,4 @@
-<div class="page">
+<div class="page page-gradient-bg">
   <header class="header">
     <div class="glow glow--left"></div>
     <div class="glow glow--right"></div>

--- a/src/app/components/browse-courts-page/browse-courts-page.component.scss
+++ b/src/app/components/browse-courts-page/browse-courts-page.component.scss
@@ -7,7 +7,17 @@ $text: #d6dde6;
 $muted: #9aa7b5;
 $white: #fff;
 
-.page { min-height: 100vh; background: $bg; color: $white; }
+.page {
+  position: relative;
+  min-height: 100vh;
+  color: $white;
+  isolation: isolate;
+
+  &.page-gradient-bg::before,
+  &.page-gradient-bg::after {
+    z-index: 0;
+  }
+}
 .container { max-width: 1280px; margin: 0 auto; padding: 0 16px; }
 
 .header {


### PR DESCRIPTION
## Summary
- add the shared `page-gradient-bg` class to the browse courts page container so the user view uses the same background as admin
- adjust the page styles to rely on the shared gradient while keeping the content layered above it

## Testing
- npm start -- --host 0.0.0.0 --port 4200 *(fails: missing module '@primeuix/themes/aura')*


------
https://chatgpt.com/codex/tasks/task_e_68d6d74099e48325a74c563475cd6d30